### PR TITLE
Create a Card

### DIFF
--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -25,11 +27,18 @@ namespace PokeMemo.ViewModels
         public ICommand SaveCardAndExitCommand { get; }
         public ICommand SaveAndCreateNextCardCommand { get; }
 
+        public event PropertyChangedEventHandler PropertyChanged;
+
         public CreateCardViewModel()
         {
             NavigateToPreviewDeckViewCommand = new RelayCommand(o => NavigateToPreviewDeckView());
             SaveCardAndExitCommand = new RelayCommand(o => SaveCardAndExit());
             SaveAndCreateNextCardCommand = new RelayCommand(o => SaveAndCreateNextCard());
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         private void NavigateToPreviewDeckView()

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -1,26 +1,35 @@
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
+using PokeMemo.Utility;
+using PokeMemo.Models;
 
 namespace PokeMemo.ViewModels
 {
     public class CreateCardViewModel : ViewModelBase
     {
-        /* Used to create a new card and display contents in the card preview */
+        /*
+         * Fields used for the creation of a card; generating the card preview
+         * and determining which controls are visible
+         */
         public string? Question { get; set; }
         public string? Answer { get; set; }
-    
+        public bool IsQuestionEmpty { get; set; } = false;
+        public bool IsAnswerEmpty { get; set; } = false;
+
         /*
          * Setting up view navigation by creating RelayCommands that call on functions
          * that update the CurrentViewModel in MainWindowViewModel
          */
         public ICommand NavigateToPreviewDeckViewCommand { get; }
-        public ICommand CreateAndSaveNewCardCommand { get; }
+        public ICommand SaveCardAndExitCommand { get; }
+        public ICommand SaveAndCreateNextCardCommand { get; }
 
         public CreateCardViewModel()
         {
             NavigateToPreviewDeckViewCommand = new RelayCommand(o => NavigateToPreviewDeckView());
-            CreateAndSaveNewCardCommand = new RelayCommand(o => CreateAndSaveNewCard());
+            SaveCardAndExitCommand = new RelayCommand(o => SaveCardAndExit());
+            SaveAndCreateNextCardCommand = new RelayCommand(o => SaveAndCreateNextCard());
         }
 
         private void NavigateToPreviewDeckView()
@@ -29,9 +38,50 @@ namespace PokeMemo.ViewModels
             mainWindowViewModel?.NavigateToPreviewDeckViewCommand.Execute(null);
         }
 
-        private void CreateAndSaveNewCard()
+        private void SaveCardAndExit()
         {
+            if (!CheckIfFieldsAreValid())
+            {
+                // TODO: Update the view
+                return;
+            }
             
+            CreateCardAndRefreshFields();
+            NavigateToPreviewDeckView();
+        }
+
+        private void SaveAndCreateNextCard()
+        {
+            if (!CheckIfFieldsAreValid())
+            {
+                // TODO: Update the view
+                return;
+            }
+            
+            CreateCardAndRefreshFields();
+        }
+
+        private bool CheckIfFieldsAreValid()
+        {
+            /* Return if either the question or answer field is empty */
+            IsQuestionEmpty = string.IsNullOrEmpty(Question);
+            IsAnswerEmpty = string.IsNullOrEmpty(Answer);
+            if (IsQuestionEmpty || IsAnswerEmpty) return false;
+            
+            return true;
+        }
+
+        private void CreateCardAndRefreshFields()
+        {
+            /* Add a new card to the currently selected deck */
+            var currentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
+            currentDeck?.AddCard(new Card(Question, Answer, "#F6BD60", "#F7EDE2", "#F7EDE2", "/Assets/squirtle.png"));
+            
+            /* Refresh the fields and update the corresponding view */
+            Question = string.Empty;
+            Answer = string.Empty;
+            IsQuestionEmpty = false;
+            IsAnswerEmpty = false;
         }
     }
 }

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -1,6 +1,33 @@
-namespace PokeMemo.ViewModels;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 
-public class CreateCardViewModel
+namespace PokeMemo.ViewModels
 {
+    public class CreateCardViewModel : ViewModelBase
+    {
+        /* Used to create a new card and display contents in the card preview */
+        public string? Question { get; set; }
+        public string? Answer { get; set; }
     
+        public ICommand NavigateToPreviewDeckViewCommand { get; }
+        public ICommand CreateAndSaveNewCardCommand { get; }
+
+        public CreateCardViewModel()
+        {
+            NavigateToPreviewDeckViewCommand = new RelayCommand(o => NavigateToPreviewDeckView());
+            CreateAndSaveNewCardCommand = new RelayCommand(o => CreateAndSaveNewCard());
+        }
+
+        private void NavigateToPreviewDeckView()
+        {
+            var mainWindowViewModel = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow?.DataContext as MainWindowViewModel;
+            mainWindowViewModel?.NavigateToPreviewDeckViewCommand.Execute(null);
+        }
+
+        private void CreateAndSaveNewCard()
+        {
+            
+        }
+    }
 }

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -10,6 +10,10 @@ namespace PokeMemo.ViewModels
         public string? Question { get; set; }
         public string? Answer { get; set; }
     
+        /*
+         * Setting up view navigation by creating RelayCommands that call on functions
+         * that update the CurrentViewModel in MainWindowViewModel
+         */
         public ICommand NavigateToPreviewDeckViewCommand { get; }
         public ICommand CreateAndSaveNewCardCommand { get; }
 

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -1,0 +1,6 @@
+namespace PokeMemo.ViewModels;
+
+public class CreateCardViewModel
+{
+    
+}

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,7 @@ namespace PokeMemo.ViewModels
         public ICommand NavigateToCreateDeckViewCommand { get; }
         public ICommand NavigateToQuizViewCommand { get; }
         public ICommand NavigateToPreviewDeckViewCommand { get; }
+        public ICommand NavigateToCreateCardViewCommand { get; }
 
         public MainWindowViewModel()
         {
@@ -25,6 +26,7 @@ namespace PokeMemo.ViewModels
             NavigateToCreateDeckViewCommand = new RelayCommand(o => NavigateToCreateDeckView());
             NavigateToQuizViewCommand = new RelayCommand(o => NavigateToQuizView());
             NavigateToPreviewDeckViewCommand = new RelayCommand(o => NavigateToPreviewDeckView());
+            NavigateToCreateCardViewCommand = new RelayCommand(o => NavigateToCreateCardView());
             CurrentView = new DeckLibraryViewModel();
         }
 
@@ -43,6 +45,11 @@ namespace PokeMemo.ViewModels
         private void NavigateToPreviewDeckView()
         {
             CurrentView = new PreviewDeckViewModel();
+        }
+
+        private void NavigateToCreateCardView()
+        {
+            CurrentView = new CreateCardViewModel();
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -18,11 +18,13 @@ namespace PokeMemo.ViewModels
     {
         private DeckLibrary DeckLibrary { get; }
         public ICommand NavigateToDeckLibraryViewCommand { get; }
+        public ICommand NavigateToCreateCardViewCommand { get; }
 
         public PreviewDeckViewModel()
         {
             DeckLibrary = DataService.Instance.DeckLibrary;
             NavigateToDeckLibraryViewCommand = new RelayCommand(o => NavigateToDeckLibraryView());
+            NavigateToCreateCardViewCommand = new RelayCommand(o => NavigateToCreateCardView());
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -34,6 +36,12 @@ namespace PokeMemo.ViewModels
         {
             var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
             mainWindowViewModel?.NavigateToDeckLibraryViewCommand.Execute(null);
+        }
+
+        private void NavigateToCreateCardView()
+        {
+            var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
+            mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(null);
         }
     }
 }

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -21,16 +21,15 @@
                 <DockPanel Height="270">
                         <!-- Card preview -->
                         <Border DockPanel.Dock="Left" Background="Chartreuse" CornerRadius="15" Margin="0,0,30,0">
-                                <StackPanel VerticalAlignment="Center" Spacing="10">
+                                <StackPanel VerticalAlignment="Center" Spacing="10" Width="200">
                                         <TextBlock 
-                                                Text="What is the radius of the Earth?" 
+                                                Text="{Binding Question}" 
                                                 TextWrapping="Wrap"
                                                 TextAlignment="Center"
                                                 FontWeight="Medium"
-                                                Margin="20,0"
-                                                MaxWidth="180" />
+                                                Margin="20,0" />
                                         <TextBlock 
-                                                Text="6.371km" 
+                                                Text="{Binding Answer}" 
                                                 TextAlignment="Center"
                                                 FontWeight="Light"/>
                                 </StackPanel>

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -42,12 +42,12 @@
                         <Grid DockPanel.Dock="Right" RowDefinitions="Auto, Auto" VerticalAlignment="Center">
                                 <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,20">
                                         <TextBlock Text="Enter a question" />
-                                        <TextBox CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBox Text="{Binding Question, UpdateSourceTrigger=PropertyChanged}" CornerRadius="5" HorizontalAlignment="Stretch" />
                                         <TextBlock Text="Please enter a question first before saving." Foreground="Red" IsEnabled="{Binding IsQuestionEmpty}"/>
                                 </StackPanel>
                                 <StackPanel Grid.Row="1" Spacing="8">
                                         <TextBlock Text="What's the answer?" />
-                                        <TextBox CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBox Text="{Binding Answer, UpdateSourceTrigger=PropertyChanged}" CornerRadius="5" HorizontalAlignment="Stretch" />
                                         <TextBlock Text="Please enter an answer first before saving." Foreground="Red" IsEnabled="{Binding IsAnswerEmpty}"/>
                                 </StackPanel>
                         </Grid>

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -6,6 +6,9 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PokeMemo.Views.CreateCardView" 
              x:DataType="local:CreateCardViewModel">
+        <Design.DataContext>
+                <local:CreateCardViewModel />
+        </Design.DataContext>
         <StackPanel Margin="30, 20" Spacing="30">
                 <!-- Title bar -->
                 <Grid Height="40" ColumnDefinitions="Auto, *, Auto">

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -1,10 +1,11 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="PokeMemo.Views.CreateCardWindow"
-        Title="CreateCard">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:PokeMemo.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="PokeMemo.Views.CreateCardView" 
+             x:DataType="local:CreateCardViewModel">
         <StackPanel Margin="30, 20" Spacing="30">
                 <!-- Title bar -->
                 <Grid Height="40" ColumnDefinitions="Auto, *, Auto">
@@ -56,4 +57,4 @@
                         </StackPanel>
                 </DockPanel>
         </StackPanel>
-</Window>
+</UserControl>

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -14,7 +14,7 @@
                                Grid.Column="0" 
                                Text="Create a new card" 
                                FontSize="32" />
-                       <Button Grid.Column="2" Content="Back" />
+                       <Button Grid.Column="2" Content="Back" Command="{Binding NavigateToPreviewDeckViewCommand}" />
                 </Grid>
                 
                 <!-- Main section -->
@@ -41,10 +41,12 @@
                                 <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,20">
                                         <TextBlock Text="Enter a question" />
                                         <TextBox CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBlock Text="Please enter a question first before saving." Foreground="Red" IsEnabled="{Binding IsQuestionEmpty}"/>
                                 </StackPanel>
                                 <StackPanel Grid.Row="1" Spacing="8">
                                         <TextBlock Text="What's the answer?" />
                                         <TextBox CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBlock Text="Please enter an answer first before saving." Foreground="Red" IsEnabled="{Binding IsAnswerEmpty}"/>
                                 </StackPanel>
                         </Grid>
                 </DockPanel>
@@ -52,8 +54,8 @@
                 <!-- Buttons to save or create new card -->
                 <DockPanel>
                         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-                                <Button Content="Save and exit" />
-                                <Button Content="Save and create next card" />
+                                <Button Content="Save and exit" Command="{Binding SaveCardAndExitCommand }" IsEnabled="True" />
+                                <Button Content="Save and create next card" Command="{Binding SaveAndCreateNextCardCommand}" IsEnabled="True"/>
                         </StackPanel>
                 </DockPanel>
         </StackPanel>

--- a/Views/CreateCardView.axaml.cs
+++ b/Views/CreateCardView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using PokeMemo.ViewModels;
 
 namespace PokeMemo.Views;
 
@@ -9,5 +10,6 @@ public partial class CreateCardView : Window
     public CreateCardView()
     {
         InitializeComponent();
+        DataContext = new CreateCardViewModel();
     }
 }

--- a/Views/CreateCardView.axaml.cs
+++ b/Views/CreateCardView.axaml.cs
@@ -5,7 +5,7 @@ using PokeMemo.ViewModels;
 
 namespace PokeMemo.Views;
 
-public partial class CreateCardView : Window
+public partial class CreateCardView : UserControl
 {
     public CreateCardView()
     {

--- a/Views/CreateCardView.axaml.cs
+++ b/Views/CreateCardView.axaml.cs
@@ -4,9 +4,9 @@ using Avalonia.Markup.Xaml;
 
 namespace PokeMemo.Views;
 
-public partial class CreateCardWindow : Window
+public partial class CreateCardView : Window
 {
-    public CreateCardWindow()
+    public CreateCardView()
     {
         InitializeComponent();
     }

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -19,6 +19,7 @@
 		
 		<DockPanel Grid.Row="0" Margin="10">
 			<TextBlock Text="View Deck" FontSize="40" FontWeight="Bold" DockPanel.Dock="Left" VerticalAlignment="Center" />
+			<Button Content="Add Card" Command="{Binding NavigateToCreateCardViewCommand}" DockPanel.Dock="Right" IsEnabled="True" />
 			<Button Content="Back to Deck Library" Command="{Binding NavigateToDeckLibraryViewCommand}" DockPanel.Dock="Right" Padding="10" />
 		</DockPanel>
 


### PR DESCRIPTION
Ramon implemented Create a Card functionality, navigation between the View Deck and Create a Card screen, with working fields for adding a card. Currently Save and Exit works to return to View Deck with the new card visible, but a bunch of functionality on Create a Card needs to be sorted out (card preview, Save and Add New Card, field validation working properly).