### PR TITLE
Create Card - Card Preview

### DIFF
--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -10,6 +10,7 @@ namespace PokeMemo.ViewModels
 {
     public class CreateCardViewModel : ViewModelBase
     {
+        public Deck CurrentDeck { get; }
         /*
          * Fields used for the creation of a card; generating the card preview
          * and determining which controls are visible
@@ -31,6 +32,7 @@ namespace PokeMemo.ViewModels
 
         public CreateCardViewModel()
         {
+            CurrentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
             NavigateToPreviewDeckViewCommand = new RelayCommand(o => NavigateToPreviewDeckView());
             SaveCardAndExitCommand = new RelayCommand(o => SaveCardAndExit());
             SaveAndCreateNextCardCommand = new RelayCommand(o => SaveAndCreateNextCard());
@@ -83,9 +85,12 @@ namespace PokeMemo.ViewModels
         private void CreateCardAndRefreshFields()
         {
             /* Add a new card to the currently selected deck */
-            var currentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
-            currentDeck?.AddCard(new Card(Question, Answer, "#F6BD60", "#F7EDE2", "#F7EDE2", "/Assets/squirtle.png"));
-            
+            var backgroundColour = CurrentDeck?.BackgroundColour ?? "#FFFFFF";
+            var foregroundColour = CurrentDeck?.ForegroundColour ?? "#000000";
+            var borderColour = CurrentDeck?.BorderColour ?? "#000000";
+
+            CurrentDeck?.AddCard(new Card(Question, Answer, backgroundColour, foregroundColour, borderColour, "/Assets/squirtle.png"));
+
             /* Refresh the fields and update the corresponding view */
             Question = string.Empty;
             Answer = string.Empty;

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using PokeMemo.Utility;
 using PokeMemo.Models;
+using ReactiveUI;
 
 namespace PokeMemo.ViewModels
 {
@@ -15,10 +16,51 @@ namespace PokeMemo.ViewModels
          * Fields used for the creation of a card; generating the card preview
          * and determining which controls are visible
          */
-        public string? Question { get; set; }
-        public string? Answer { get; set; }
-        public bool IsQuestionEmpty { get; set; } = false;
-        public bool IsAnswerEmpty { get; set; } = false;
+        private string? _question;
+        public string? Question
+        {
+            get => _question;
+            set
+            {
+                _question = value;
+                this.RaiseAndSetIfChanged(ref _question, value);
+            }
+        }
+
+        private string? _answer;
+
+        public string? Answer
+        {
+            get => _answer;
+            set
+            {
+                _answer = value;
+                this.RaiseAndSetIfChanged(ref _answer, value);
+            }
+        }
+
+        private bool _isQuestionEmpty;
+        public bool IsQuestionEmpty
+        {
+            get => _isQuestionEmpty;
+            set
+            {
+                _isQuestionEmpty = value;
+                this.RaiseAndSetIfChanged(ref _isQuestionEmpty, value);
+            }
+        }
+        
+        private bool _isAnswerEmpty;
+
+        public bool IsAnswerEmpty
+        {
+            get => _isAnswerEmpty;
+            set
+            {
+                _isAnswerEmpty = value;
+                this.RaiseAndSetIfChanged(ref _isAnswerEmpty, value);
+            }
+        }
 
         /*
          * Setting up view navigation by creating RelayCommands that call on functions

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -26,13 +26,13 @@
                         <Border DockPanel.Dock="Left" Background="Chartreuse" CornerRadius="15" Margin="0,0,30,0">
                                 <StackPanel VerticalAlignment="Center" Spacing="10" Width="200">
                                         <TextBlock 
-                                                Text="{Binding Question}" 
+                                                Text="{Binding #Question.Text}" 
                                                 TextWrapping="Wrap"
                                                 TextAlignment="Center"
                                                 FontWeight="Medium"
                                                 Margin="20,0" />
                                         <TextBlock 
-                                                Text="{Binding Answer}" 
+                                                Text="{Binding #Answer.Text}" 
                                                 TextAlignment="Center"
                                                 FontWeight="Light"/>
                                 </StackPanel>
@@ -42,12 +42,12 @@
                         <Grid DockPanel.Dock="Right" RowDefinitions="Auto, Auto" VerticalAlignment="Center">
                                 <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,20">
                                         <TextBlock Text="Enter a question" />
-                                        <TextBox Text="{Binding Question, UpdateSourceTrigger=PropertyChanged}" CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBox Text="{Binding Question, UpdateSourceTrigger=PropertyChanged}" Name="Question" CornerRadius="5" HorizontalAlignment="Stretch" />
                                         <TextBlock Text="Please enter a question first before saving." Foreground="Red" IsEnabled="{Binding IsQuestionEmpty}"/>
                                 </StackPanel>
                                 <StackPanel Grid.Row="1" Spacing="8">
                                         <TextBlock Text="What's the answer?" />
-                                        <TextBox Text="{Binding Answer, UpdateSourceTrigger=PropertyChanged}" CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBox Text="{Binding Answer, UpdateSourceTrigger=PropertyChanged}" Name="Answer" CornerRadius="5" HorizontalAlignment="Stretch" />
                                         <TextBlock Text="Please enter an answer first before saving." Foreground="Red" IsEnabled="{Binding IsAnswerEmpty}"/>
                                 </StackPanel>
                         </Grid>

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -46,13 +46,13 @@
                         <Grid DockPanel.Dock="Right" RowDefinitions="Auto, Auto" VerticalAlignment="Center">
                                 <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,20">
                                         <TextBlock Text="Enter a question" />
-                                        <TextBox Text="{Binding Question, UpdateSourceTrigger=PropertyChanged}" Name="Question" CornerRadius="5" HorizontalAlignment="Stretch" />
-                                        <TextBlock Text="Please enter a question first before saving." Foreground="Red" IsEnabled="{Binding IsQuestionEmpty}"/>
+                                        <TextBox Text="{Binding Question}" Name="Question" CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBlock Text="Please enter a question first before saving." Foreground="Red" IsVisible="{Binding IsQuestionEmpty}"/>
                                 </StackPanel>
                                 <StackPanel Grid.Row="1" Spacing="8">
                                         <TextBlock Text="What's the answer?" />
-                                        <TextBox Text="{Binding Answer, UpdateSourceTrigger=PropertyChanged}" Name="Answer" CornerRadius="5" HorizontalAlignment="Stretch" />
-                                        <TextBlock Text="Please enter an answer first before saving." Foreground="Red" IsEnabled="{Binding IsAnswerEmpty}"/>
+                                        <TextBox Text="{Binding Answer}" Name="Answer" CornerRadius="5" HorizontalAlignment="Stretch" />
+                                        <TextBlock Text="Please enter an answer first before saving." Foreground="Red" IsVisible="{Binding IsAnswerEmpty}"/>
                                 </StackPanel>
                         </Grid>
                 </DockPanel>

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -21,20 +21,24 @@
                 </Grid>
                 
                 <!-- Main section -->
-                <DockPanel Height="270">
+                <DockPanel >
                         <!-- Card preview -->
-                        <Border DockPanel.Dock="Left" Background="Chartreuse" CornerRadius="15" Margin="0,0,30,0">
+                        <Border DockPanel.Dock="Left" Width="300" Height="375" Background="{Binding CurrentDeck.BackgroundColour}" BorderBrush="{Binding CurrentDeck.BorderColour}" BorderThickness="15" CornerRadius="10" Margin="0,0,30,0">
                                 <StackPanel VerticalAlignment="Center" Spacing="10" Width="200">
                                         <TextBlock 
                                                 Text="{Binding #Question.Text}" 
+												Foreground="{Binding CurrentDeck.ForegroundColour}"
                                                 TextWrapping="Wrap"
                                                 TextAlignment="Center"
-                                                FontWeight="Medium"
-                                                Margin="20,0" />
+												FontSize="25"
+                                                FontWeight="Bold"
+                                                Margin="10,20" />
                                         <TextBlock 
                                                 Text="{Binding #Answer.Text}" 
+												Foreground="{Binding CurrentDeck.ForegroundColour}"
                                                 TextAlignment="Center"
-                                                FontWeight="Light"/>
+												FontSize="20"
+                                                FontWeight="Bold" />
                                 </StackPanel>
                         </Border>
                         


### PR DESCRIPTION
The card preview when filling in the fields is now working as it is bound to the Control element in the corresponding `.axaml`. 

When clicking on `Save and Create Next Card`, the card *is* saved and the fields `Question` and `Answer` are set to empty, making it impossible to click on `Save and Exit` or `Save and Create Next Card`, but the fields aren't visually emptied in the View and the red text doesn't appear to alert the user that the fields are invalid.

I think it's okay for now and we can work on fixing that issue later.