### PR TITLE
Fixing issues with updating view on quiz

### DIFF
--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -23,7 +23,6 @@ namespace PokeMemo.ViewModels
             set
             {
                 _question = value;
-                this.RaiseAndSetIfChanged(ref _question, value);
             }
         }
 
@@ -35,7 +34,6 @@ namespace PokeMemo.ViewModels
             set
             {
                 _answer = value;
-                this.RaiseAndSetIfChanged(ref _answer, value);
             }
         }
 
@@ -46,7 +44,6 @@ namespace PokeMemo.ViewModels
             set
             {
                 _isQuestionEmpty = value;
-                this.RaiseAndSetIfChanged(ref _isQuestionEmpty, value);
             }
         }
         
@@ -58,7 +55,6 @@ namespace PokeMemo.ViewModels
             set
             {
                 _isAnswerEmpty = value;
-                this.RaiseAndSetIfChanged(ref _isAnswerEmpty, value);
             }
         }
 

--- a/ViewModels/DeckLibraryViewModel.cs
+++ b/ViewModels/DeckLibraryViewModel.cs
@@ -45,8 +45,11 @@ namespace PokeMemo.ViewModels
         }
         private void NavigateToQuizView()
         {
-            var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
-            mainWindowViewModel?.NavigateToQuizViewCommand.Execute(null);
+            if (DeckLibrary.SelectedDeck != null)
+            {
+                var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
+                mainWindowViewModel?.NavigateToQuizViewCommand.Execute(null);
+            }
         }
         private void NavigateToPreviewDeckView()
         {

--- a/ViewModels/QuizViewModel.cs
+++ b/ViewModels/QuizViewModel.cs
@@ -49,11 +49,13 @@ namespace PokeMemo.ViewModels
             NavigateToQuizResultsViewCommand = new RelayCommand(o => NavigateToQuizResultsView());
         }
 
+        /*
         public event PropertyChangedEventHandler PropertyChanged;
         protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+        */
 
         private void StartNewQuiz()
         {

--- a/ViewModels/QuizViewModel.cs
+++ b/ViewModels/QuizViewModel.cs
@@ -1,16 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using PokeMemo.Models;
 using PokeMemo.Utility;
-using ReactiveUI;
 
 namespace PokeMemo.ViewModels
 {
@@ -19,10 +14,33 @@ namespace PokeMemo.ViewModels
         private DeckLibrary DeckLibrary { get; }
         private List<Card> _shuffledCards;
         private int _currentCardIndex;
-        public Card CurrentCard { get; set; }
+
+        private string _currentCardText;
+
+        public string CurrentCardText
+        {
+            get => _currentCardText;
+            set
+            {
+                _currentCardText = value;
+                OnPropertyChanged(nameof(CurrentCardText));
+            }
+        }
+
+        private Card _currentCard;
+        public Card CurrentCard
+        {
+            get => _currentCard;
+            set
+            {
+                _currentCard = value;
+                OnPropertyChanged(nameof(CurrentCard));
+            }
+        }
 
         public ICommand DontRememberCommand { get; }
         public ICommand RememberCommand { get; }
+        public ICommand RevealAnswerCommand { get; }
 
         public ICommand NavigateToDeckLibraryViewCommand { get; }
         public ICommand NavigateToQuizResultsViewCommand { get; }
@@ -42,20 +60,14 @@ namespace PokeMemo.ViewModels
             _shuffledCards = DeckLibrary.SelectedDeck?.Cards.OrderBy(c => Guid.NewGuid()).ToList();
             _currentCardIndex = 0;
             CurrentCard = _shuffledCards[_currentCardIndex];
+            CurrentCardText = CurrentCard.Question;
 
             DontRememberCommand = new RelayCommand(o => DontRememberCard());
             RememberCommand = new RelayCommand(o => RememberCard());
+            RevealAnswerCommand = new RelayCommand(o => CurrentCardText = CurrentCard.Answer);
             NavigateToDeckLibraryViewCommand = new RelayCommand(o => NavigateToDeckLibraryView());
             NavigateToQuizResultsViewCommand = new RelayCommand(o => NavigateToQuizResultsView());
         }
-
-        /*
-        public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-        */
 
         private void StartNewQuiz()
         {
@@ -80,10 +92,7 @@ namespace PokeMemo.ViewModels
             {
                 _currentCardIndex++;
                 CurrentCard = _shuffledCards[_currentCardIndex];
-                OnPropertyChanged(nameof(CurrentCard));
-                OnPropertyChanged(nameof(CurrentCard.Question));
-
-                Console.WriteLine($"CurrentCard: {CurrentCard.Question}");
+                CurrentCardText = CurrentCard.Question;
             }
             else
             {

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -1,7 +1,8 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using ReactiveUI;
 
 namespace PokeMemo.ViewModels;
 
-public class ViewModelBase : ReactiveObject
+public class ViewModelBase : ObservableObject
 {
 }

--- a/Views/QuizView.axaml
+++ b/Views/QuizView.axaml
@@ -3,10 +3,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:local="clr-namespace:PokeMemo.ViewModels"
-			 xmlns:models="clr-namespace:PokeMemo.Models"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PokeMemo.Views.QuizView"
-			 x:CompileBindings="False">
+			 x:DataType="local:QuizViewModel"
+             x:CompileBindings="False">
 	<Design.DataContext>
 		<local:QuizViewModel/>
 	</Design.DataContext>

--- a/Views/QuizView.axaml
+++ b/Views/QuizView.axaml
@@ -40,7 +40,7 @@
 			Margin="50,20,50,100">
 
 			<TextBlock
-				Text="{Binding CurrentCard.Question}"
+				Text="{Binding CurrentCardText}"
 				Foreground="{Binding DeckLibrary.SelectedDeck.ForegroundColour}"
 				FontSize="40"
 				FontWeight="Bold"
@@ -48,7 +48,8 @@
 				VerticalAlignment="Center"
 				TextWrapping="Wrap"
 				TextAlignment="Center"
-				Padding="20" />
+				Padding="20" 
+				PointerPressed="InputElement_OnPointerPressed"/>
 		</Border>
 
 		<!-- Buttons -->

--- a/Views/QuizView.axaml.cs
+++ b/Views/QuizView.axaml.cs
@@ -1,6 +1,5 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Input;
 using PokeMemo.ViewModels;
 
 namespace PokeMemo.Views;
@@ -11,5 +10,11 @@ public partial class QuizView : UserControl
     {
         InitializeComponent();
         DataContext = new QuizViewModel();
+    }
+
+    private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        QuizViewModel vm = (QuizViewModel)DataContext;
+        vm.RevealAnswerCommand.Execute(null);
     }
 }


### PR DESCRIPTION
Resolving issues where the view wasn't updating after clicking either `Remember` or `Don't Remember` button. I believe the issue was occurring because of the use of our own implementation of `OnPropertyChanged` which I think is unnecessary. After updating our `ViewModelBase` to inherit from `ObservableObject` and looking into the `ObservableObject` source code, you can see that that class has its own implementation of `OnPropertyChanged` which we can utilise to update the view.

Another feature I quickly added in was the ability to update the quiz text to reveal the answer when you click on the question. This was just done with some simple code-behind that takes the `DataContext` and casts it to the `QuizViewModel` to execute the `RevealAnswer` `RelayCommand`. 