### PR TITLE
Deleting cards from currently selected deck

### DIFF
--- a/Models/Deck.cs
+++ b/Models/Deck.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Avalonia.Media.Imaging;
 using PokeMemo.Utility;
 
@@ -13,7 +14,8 @@ namespace PokeMemo.Models
         public string Name { get; set; }
         public string Category { get; set; }
         public PokemonType Type { get; set; }
-        public List<Card> Cards { get; set; }
+        
+        public ObservableCollection<Card> Cards { get; set; }
 
         [ObservableProperty]
         private string _backgroundColour;
@@ -33,7 +35,7 @@ namespace PokeMemo.Models
             Name = name;
             Category = category;
             Type = type;
-            Cards = new List<Card>();
+            Cards = new ObservableCollection<Card>();
             _backgroundColour = type.BackgroundColour;
             _foregroundColour = type.ForegroundColour;
             _borderColour = type.BorderColour;

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls.ApplicationLifetimes;
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Controls.ApplicationLifetimes;
 using PokeMemo.Models;
 using PokeMemo.Utility;
 using System.Windows.Input;
@@ -13,6 +15,8 @@ namespace PokeMemo.ViewModels
         public ICommand NavigateToDeckLibraryViewCommand { get; }
         public ICommand NavigateToCreateCardViewCommand { get; }
         public ICommand DeleteSelectedCardCommand { get; }
+        
+        public int SelectedCardIndex { get; set; }
 
         public PreviewDeckViewModel()
         {
@@ -36,6 +40,8 @@ namespace PokeMemo.ViewModels
 
         private void DeleteSelectedCard()
         {
+            DeckLibrary?.SelectedDeck?.Cards.RemoveAt(SelectedCardIndex);
+            OnPropertyChanged(nameof(DeckLibrary.SelectedDeck.Cards));
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Controls.ApplicationLifetimes;
 using PokeMemo.Models;
 using PokeMemo.Utility;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Avalonia;
 using CommunityToolkit.Mvvm.Input;
@@ -14,12 +12,14 @@ namespace PokeMemo.ViewModels
         private DeckLibrary DeckLibrary { get; }
         public ICommand NavigateToDeckLibraryViewCommand { get; }
         public ICommand NavigateToCreateCardViewCommand { get; }
+        public ICommand DeleteSelectedCardCommand { get; }
 
         public PreviewDeckViewModel()
         {
             DeckLibrary = DataService.Instance.DeckLibrary;
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             NavigateToCreateCardViewCommand = new RelayCommand(NavigateToCreateCardView);
+            DeleteSelectedCardCommand = new RelayCommand(DeleteSelectedCard);
         }
 
         private void NavigateToDeckLibraryView()
@@ -32,6 +32,10 @@ namespace PokeMemo.ViewModels
         {
             var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
             mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(null);
+        }
+
+        private void DeleteSelectedCard()
+        {
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -6,6 +6,7 @@ using PokeMemo.Utility;
 using System.Windows.Input;
 using Avalonia;
 using CommunityToolkit.Mvvm.Input;
+using DynamicData;
 
 namespace PokeMemo.ViewModels
 {
@@ -16,14 +17,16 @@ namespace PokeMemo.ViewModels
         public ICommand NavigateToCreateCardViewCommand { get; }
         public ICommand DeleteSelectedCardCommand { get; }
         
-        public int SelectedCardIndex { get; set; }
+        public List<Card> SelectedCards { get; set; }
 
         public PreviewDeckViewModel()
         {
             DeckLibrary = DataService.Instance.DeckLibrary;
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             NavigateToCreateCardViewCommand = new RelayCommand(NavigateToCreateCardView);
-            DeleteSelectedCardCommand = new RelayCommand(DeleteSelectedCard);
+            DeleteSelectedCardCommand = new RelayCommand(DeleteSelectedCards);
+            
+            SelectedCards = new List<Card>();
         }
 
         private void NavigateToDeckLibraryView()
@@ -38,10 +41,17 @@ namespace PokeMemo.ViewModels
             mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(null);
         }
 
-        private void DeleteSelectedCard()
+        private void DeleteSelectedCards()
         {
-            DeckLibrary?.SelectedDeck?.Cards.RemoveAt(SelectedCardIndex);
-            OnPropertyChanged(nameof(DeckLibrary.SelectedDeck.Cards));
+            try
+            {
+                DeckLibrary?.SelectedDeck?.Cards.RemoveMany(SelectedCards);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -49,7 +49,7 @@ namespace PokeMemo.ViewModels
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Console.WriteLine("Unable to remove selected cards. {0}", e.Message);
                 throw;
             }
         }

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -120,7 +120,8 @@
 							<ListBox 
 								ItemsSource="{Binding DeckLibrary.SelectedDeck.Cards}" 
 								Margin="0" 
-								SelectionMode="Single">
+								SelectionMode="Multiple"
+								SelectedIndex="{Binding SelectedCardIndex}">
 								
 								<ListBox.ItemsPanel>
 									<ItemsPanelTemplate>

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -166,6 +166,13 @@
 								</ListBox.ItemTemplate>
 							</ListBox>
 						</ScrollViewer>
+						<StackPanel>
+							<Button Background="White"
+							        Foreground="Black"
+							        Content="Delete card" 
+							        HorizontalAlignment="Right"
+							        Command="{Binding DeleteSelectedCardCommand}"/>
+						</StackPanel>
 					</Grid>
 				</SplitView.Content>
 		</SplitView>

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -121,7 +121,8 @@
 								ItemsSource="{Binding DeckLibrary.SelectedDeck.Cards}" 
 								Margin="0" 
 								SelectionMode="Multiple"
-								SelectedIndex="{Binding SelectedCardIndex}">
+								SelectedIndex="{Binding SelectedCardIndex}"
+								SelectedItems="{Binding SelectedCards}">
 								
 								<ListBox.ItemsPanel>
 									<ItemsPanelTemplate>


### PR DESCRIPTION
Implemented the ability to delete cards that are selected in the current deck by converting our `List<Card>` to `ObservableCollection<Card>` so that it automatically updates the view when cards are removed.