### PR TITLE
Modify currently selected card

### DIFF
--- a/Models/Card.cs
+++ b/Models/Card.cs
@@ -8,8 +8,8 @@ namespace PokeMemo.Models
     {
         private static int _nextId = 1;
         public int Id { get; set; }
-        public string Question { get; set; }
-        public string Answer { get; set; }
+        public string? Question { get; set; }
+        public string? Answer { get; set; }
 
         [ObservableProperty]
         private string _backgroundColour;
@@ -23,7 +23,7 @@ namespace PokeMemo.Models
         [ObservableProperty]
         private Bitmap _imageSource;
 
-        public Card(string question, string answer, string backgroundColour, string foregroundColour, string borderColour, string imageSource)
+        public Card(string? question, string? answer, string backgroundColour, string foregroundColour, string borderColour, string imageSource)
         {
             Id = _nextId++;
             Question = question;

--- a/Models/Deck.cs
+++ b/Models/Deck.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Avalonia.Media.Imaging;
 using PokeMemo.Utility;
 
@@ -13,7 +14,7 @@ namespace PokeMemo.Models
         public string Name { get; set; }
         public string Category { get; set; }
         public PokemonType Type { get; set; }
-        public List<Card> Cards { get; set; }
+        public ObservableCollection<Card> Cards { get; set; }
 
         [ObservableProperty]
         private string _backgroundColour;
@@ -33,7 +34,7 @@ namespace PokeMemo.Models
             Name = name;
             Category = category;
             Type = type;
-            Cards = new List<Card>();
+            Cards = new ObservableCollection<Card>();
             _backgroundColour = type.BackgroundColour;
             _foregroundColour = type.ForegroundColour;
             _borderColour = type.BorderColour;

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -13,6 +13,9 @@ namespace PokeMemo.ViewModels
     public class CreateCardViewModel : ViewModelBase
     {
         public Deck? CurrentDeck { get; }
+
+        private Card? _cardToBeModified;
+        
         /*
          * Fields used for the creation of a card; generating the card preview
          * and determining which controls are visible
@@ -63,6 +66,18 @@ namespace PokeMemo.ViewModels
             }
         }
 
+        private string _leftButtonText;
+
+        public string LeftButtonText
+        {
+            get => _leftButtonText;
+            set
+            {
+                _leftButtonText = value;
+                OnPropertyChanged();
+            }
+        }
+
         /*
          * Setting up view navigation by creating RelayCommands that call on functions
          * that update the CurrentViewModel in MainWindowViewModel
@@ -71,23 +86,39 @@ namespace PokeMemo.ViewModels
         public ICommand SaveCardAndExitCommand { get; }
         public ICommand SaveAndCreateNextCardCommand { get; }
 
+        /*
+         * Initialise the view with empty fields to create a new card and
+         * set the content of the button to indicate to the user that they
+         * are creating a new card, adding it to the deck and then
+         * exiting.
+         */
         public CreateCardViewModel()
         {
             CurrentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
             NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
             SaveCardAndExitCommand = new RelayCommand(SaveCardAndExit);
             SaveAndCreateNextCardCommand = new RelayCommand(SaveAndCreateNextCard);
+
+            LeftButtonText = "Save card and exit";
         }
 
-        public CreateCardViewModel(string? question, string? answer)
+        /*
+         * If there is a card to be modified, set this and the corresponding fields
+         * in the view to its existing Question and Answer fields. This will also
+         * set the button to indicate to the user that they're modifying an existing
+         * card and then exiting.
+         */
+        public CreateCardViewModel(Card? cardToBeModified)
         {
             CurrentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
             NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
             SaveCardAndExitCommand = new RelayCommand(SaveCardAndExit);
             SaveAndCreateNextCardCommand = new RelayCommand(SaveAndCreateNextCard);
 
-            Question = question;
-            Answer = answer;
+            _cardToBeModified = cardToBeModified;
+            Question = cardToBeModified?.Question;
+            Answer = cardToBeModified?.Answer;
+            LeftButtonText = "Modify card and exit";
         }
 
         private void NavigateToPreviewDeckView()
@@ -98,6 +129,14 @@ namespace PokeMemo.ViewModels
 
         private void SaveCardAndExit()
         {
+            if (_cardToBeModified != null)
+            {
+               _cardToBeModified.Question = Question;
+               _cardToBeModified.Answer = Answer;
+               NavigateToPreviewDeckView();
+               return;
+            }
+            
             if (CheckIfFieldsAreValid())
             {
                 CreateCardAndRefreshFields();

--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -12,7 +12,7 @@ namespace PokeMemo.ViewModels
 {
     public class CreateCardViewModel : ViewModelBase
     {
-        public Deck CurrentDeck { get; }
+        public Deck? CurrentDeck { get; }
         /*
          * Fields used for the creation of a card; generating the card preview
          * and determining which controls are visible
@@ -77,6 +77,17 @@ namespace PokeMemo.ViewModels
             NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
             SaveCardAndExitCommand = new RelayCommand(SaveCardAndExit);
             SaveAndCreateNextCardCommand = new RelayCommand(SaveAndCreateNextCard);
+        }
+
+        public CreateCardViewModel(string? question, string? answer)
+        {
+            CurrentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
+            NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
+            SaveCardAndExitCommand = new RelayCommand(SaveCardAndExit);
+            SaveAndCreateNextCardCommand = new RelayCommand(SaveAndCreateNextCard);
+
+            Question = question;
+            Answer = answer;
         }
 
         private void NavigateToPreviewDeckView()

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using ReactiveUI;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PokeMemo.Models;
 
 namespace PokeMemo.ViewModels
 {
@@ -27,7 +28,7 @@ namespace PokeMemo.ViewModels
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibrary);
             NavigateToCreateDeckViewCommand = new RelayCommand(NavigateToCreateDeckView);
             NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
-            NavigateToCreateCardViewCommand = new RelayCommand(NavigateToCreateCardView);
+            NavigateToCreateCardViewCommand = new RelayCommand<Card>(NavigateToCreateCardView);
             NavigateToQuizViewCommand = new RelayCommand(NavigateToQuizView);
             NavigateToQuizResultsViewCommand = new RelayCommand(NavigateToQuizResultsView);
             CurrentView = new DeckLibraryViewModel();
@@ -46,9 +47,16 @@ namespace PokeMemo.ViewModels
             CurrentView = new PreviewDeckViewModel();
         }
 
-        private void NavigateToCreateCardView()
+        private void NavigateToCreateCardView(Card? selectedCard)
         {
-            CurrentView = new CreateCardViewModel();
+            if (selectedCard == null)
+            {
+                CurrentView = new CreateCardViewModel();
+            }
+            else
+            {
+                CurrentView = new CreateCardViewModel(selectedCard?.Question, selectedCard?.Answer);
+            }
         }
         private void NavigateToQuizView()
         {

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -47,6 +47,10 @@ namespace PokeMemo.ViewModels
             CurrentView = new PreviewDeckViewModel();
         }
 
+        /*
+         * If we have received a selectedCard, lets move to the CreateCardView with the
+         * Question and Answer fields pre-filled with the selected card's question and answer.
+         */
         private void NavigateToCreateCardView(Card? selectedCard)
         {
             if (selectedCard == null)
@@ -55,7 +59,7 @@ namespace PokeMemo.ViewModels
             }
             else
             {
-                CurrentView = new CreateCardViewModel(selectedCard?.Question, selectedCard?.Answer);
+                CurrentView = new CreateCardViewModel(selectedCard);
             }
         }
         private void NavigateToQuizView()

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.ApplicationLifetimes;
+﻿using System;
+using Avalonia.Controls.ApplicationLifetimes;
 using PokeMemo.Models;
 using PokeMemo.Utility;
 using System.ComponentModel;
@@ -14,12 +15,16 @@ namespace PokeMemo.ViewModels
         private DeckLibrary DeckLibrary { get; }
         public ICommand NavigateToDeckLibraryViewCommand { get; }
         public ICommand NavigateToCreateCardViewCommand { get; }
+        public ICommand ModifyCardCommand { get; }
+        
+        public Card SelectedCard { get; set; }
 
         public PreviewDeckViewModel()
         {
             DeckLibrary = DataService.Instance.DeckLibrary;
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
-            NavigateToCreateCardViewCommand = new RelayCommand(NavigateToCreateCardView);
+            NavigateToCreateCardViewCommand = new RelayCommand<Card>(NavigateToCreateCardView);
+            ModifyCardCommand = new RelayCommand(ModifyCard);
         }
 
         private void NavigateToDeckLibraryView()
@@ -28,10 +33,23 @@ namespace PokeMemo.ViewModels
             mainWindowViewModel?.NavigateToDeckLibraryViewCommand.Execute(null);
         }
 
-        private void NavigateToCreateCardView()
+        private void NavigateToCreateCardView(Card? selectedCard)
         {
             var mainWindowViewModel = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow.DataContext as MainWindowViewModel;
-            mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(null);
+
+            if (selectedCard == null)
+            {
+                mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(null);
+            }
+            else
+            {
+                mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(selectedCard);
+            }
+        }
+
+        private void ModifyCard()
+        {
+            NavigateToCreateCardViewCommand.Execute(SelectedCard);
         }
     }
 }

--- a/ViewModels/QuizViewModel.cs
+++ b/ViewModels/QuizViewModel.cs
@@ -16,9 +16,9 @@ namespace PokeMemo.ViewModels
         private List<Card> _shuffledCards;
         private int _currentCardIndex;
 
-        private string _currentCardText;
+        private string? _currentCardText;
 
-        public string CurrentCardText
+        public string? CurrentCardText
         {
             get => _currentCardText;
             set

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -68,7 +68,7 @@
                 <!-- Buttons to save or create new card -->
                 <DockPanel>
                         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-                                <Button Content="Save and exit" Command="{Binding SaveCardAndExitCommand }" IsEnabled="True" />
+                                <Button Content="{Binding LeftButtonText}" Command="{Binding SaveCardAndExitCommand }" IsEnabled="True" />
                                 <Button Content="Save and create next card" Command="{Binding SaveAndCreateNextCardCommand}" IsEnabled="True"/>
                         </StackPanel>
                 </DockPanel>

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -120,7 +120,8 @@
 							<ListBox 
 								ItemsSource="{Binding DeckLibrary.SelectedDeck.Cards}" 
 								Margin="0" 
-								SelectionMode="Single">
+								SelectionMode="Single"
+								SelectedItem="{Binding SelectedCard}">
 								
 								<ListBox.ItemsPanel>
 									<ItemsPanelTemplate>
@@ -166,6 +167,14 @@
 								</ListBox.ItemTemplate>
 							</ListBox>
 						</ScrollViewer>
+						<StackPanel>
+							<Button Background="White"
+							        Foreground="Black"
+							        Content="Modify card" 
+							        HorizontalAlignment="Right"
+							        Command="{Binding ModifyCardCommand}"
+							        CommandParameter="{Binding SelectedCard}"/>
+						</StackPanel>
 					</Grid>
 				</SplitView.Content>
 		</SplitView>


### PR DESCRIPTION
We can now modify the currently selected card utilising the same `CreateCard` view model and view by overloading the constructor of `CreateCardViewModel` to take a `Card` object. The `CreateCardViewModel` had some code changes to add an optional field, `Card? _cardToBeModified` which is checked to see if it's not null. 

If it's not null, then we initialise the TextBlock fields with its question and answer, and then set it's Question and Answer when the user clicks `Modify and exit`.