### PR TITLE
Disabling SaveAndCreateNextCard button when trying to modify a card.

### DIFF
--- a/ViewModels/CreateCardViewModel.cs
+++ b/ViewModels/CreateCardViewModel.cs
@@ -78,6 +78,18 @@ namespace PokeMemo.ViewModels
             }
         }
 
+        private bool _isCreateNextCardEnabled = true;
+
+        public bool IsCreateNextCardEnabled
+        {
+            get => _isCreateNextCardEnabled;
+            set
+            {
+                _isCreateNextCardEnabled = value;
+                OnPropertyChanged();
+            }
+        }
+
         /*
          * Setting up view navigation by creating RelayCommands that call on functions
          * that update the CurrentViewModel in MainWindowViewModel
@@ -119,6 +131,7 @@ namespace PokeMemo.ViewModels
             Question = cardToBeModified?.Question;
             Answer = cardToBeModified?.Answer;
             LeftButtonText = "Modify card and exit";
+            IsCreateNextCardEnabled = false;
         }
 
         private void NavigateToPreviewDeckView()

--- a/Views/CreateCardView.axaml
+++ b/Views/CreateCardView.axaml
@@ -69,7 +69,7 @@
                 <DockPanel>
                         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
                                 <Button Content="{Binding LeftButtonText}" Command="{Binding SaveCardAndExitCommand }" IsEnabled="True" />
-                                <Button Content="Save and create next card" Command="{Binding SaveAndCreateNextCardCommand}" IsEnabled="True"/>
+                                <Button Content="Save and create next card" Command="{Binding SaveAndCreateNextCardCommand}" IsEnabled="{Binding IsCreateNextCardEnabled}" IsVisible="{Binding IsCreateNextCardEnabled}" />
                         </StackPanel>
                 </DockPanel>
         </StackPanel>


### PR DESCRIPTION
Fixed issue where modifying a card left the `Save and create next card` button enabled and if you clicked it, it would modify the card *and* add a new card.

Just disabled the button and made it invisible when modifying a card.