### PR TITLE
Implementing modify and delete deck

### DIFF
--- a/Models/Card.cs
+++ b/Models/Card.cs
@@ -14,17 +14,49 @@ namespace PokeMemo.Models
         public string? Answer { get; set; }
 
         // These properties are used to set the colours and image of the card.
-        [ObservableProperty]
         private string _backgroundColour;
+        public string BackgroundColour
+        {
+            get => _backgroundColour;
+            set
+            {
+                _backgroundColour = value;
+                OnPropertyChanged();
+            }
+        }
 
-        [ObservableProperty]
         private string _foregroundColour;
+        public string ForegroundColour
+        {
+            get => _foregroundColour;
+            set
+            {
+                _foregroundColour = value;
+                OnPropertyChanged();
+            }
+        }
 
-        [ObservableProperty]
         private string _borderColour;
+        public string BorderColour
+        {
+            get => _borderColour;
+            set
+            {
+                _borderColour = value;
+                OnPropertyChanged();
+            }
+        }
 
-        [ObservableProperty]
         private Bitmap _imageSource;
+        public Bitmap ImageSource
+        {
+            get => _imageSource;
+            set
+            {
+                _imageSource = value;
+                OnPropertyChanged();
+            }
+        }
 
         // In practice the colours are set by the Deck the Card belongs to.
         // And the image is set using ImageHelper's GetImageByType method to randomise the pokemon image based on the type of the Deck.
@@ -33,10 +65,10 @@ namespace PokeMemo.Models
             Id = _nextId++;
             Question = question;
             Answer = answer;
-            _backgroundColour = backgroundColour;
-            _foregroundColour = foregroundColour;
-            _borderColour = borderColour;
-            _imageSource = ImageHelper.LoadFromResource(imageSource);
+            BackgroundColour = backgroundColour;
+            ForegroundColour = foregroundColour;
+            BorderColour = borderColour;
+            ImageSource = ImageHelper.LoadFromResource(imageSource);
         }
     }
 }

--- a/Models/Deck.cs
+++ b/Models/Deck.cs
@@ -15,24 +15,68 @@ namespace PokeMemo.Models
         public string? Category { get; set; }
 
         // The PokemonType property is used to set the colours and image of the deck.
-        public PokemonType Type { get; set; }
+        private PokemonType _type;
+        public PokemonType Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                OnPropertyChanged();
+            }
+        }
 
         // The Cards property is an observable collection of Card objects, which means that changes to the collection can be observed by the UI.
         public ObservableCollection<Card> Cards { get; set; }
 
         // These properties are used to set the colours and image of the Deck.
         // They are also passed to the Cards when they are added to the Deck.
-        [ObservableProperty]
         private string _backgroundColour;
 
-        [ObservableProperty]
+        public string BackgroundColour
+        {
+            get => _backgroundColour;
+            set
+            {
+                _backgroundColour = value;
+                OnPropertyChanged();
+            }
+        }
+
         private string _foregroundColour;
 
-        [ObservableProperty]
-        private string _borderColour;
+        public string ForegroundColour
+        {
+            get => _foregroundColour;
+            set
+            {
+                _foregroundColour = value;
+                OnPropertyChanged();
+            }
+        }
 
-        [ObservableProperty]
+        private string _borderColour;
+        public string BorderColour
+        {
+            get => _borderColour;
+            set
+            {
+                _borderColour = value;
+                OnPropertyChanged();
+            }
+        }
+
         private Bitmap _imageSource;
+
+        public Bitmap ImageSource
+        {
+            get => _imageSource;
+            set
+            {
+                _imageSource = value;
+                OnPropertyChanged();
+            }
+        }
 
         // The colours and image of the Deck are set based on the PokemonType of the Deck.
         // The list of PokemonTypes is defined in the DeckLibrary class.
@@ -43,9 +87,9 @@ namespace PokeMemo.Models
             Category = category;
             Type = type;
             Cards = new ObservableCollection<Card>();
-            _backgroundColour = type.BackgroundColour;
-            _foregroundColour = type.ForegroundColour;
-            _borderColour = type.BorderColour;
+            BackgroundColour = type.BackgroundColour;
+            ForegroundColour = type.ForegroundColour;
+            BorderColour = type.BorderColour;
             _imageSource = type.ImageSource;
         }
 

--- a/Models/Deck.cs
+++ b/Models/Deck.cs
@@ -32,7 +32,6 @@ namespace PokeMemo.Models
         // These properties are used to set the colours and image of the Deck.
         // They are also passed to the Cards when they are added to the Deck.
         private string _backgroundColour;
-
         public string BackgroundColour
         {
             get => _backgroundColour;
@@ -44,7 +43,6 @@ namespace PokeMemo.Models
         }
 
         private string _foregroundColour;
-
         public string ForegroundColour
         {
             get => _foregroundColour;
@@ -67,7 +65,6 @@ namespace PokeMemo.Models
         }
 
         private Bitmap _imageSource;
-
         public Bitmap ImageSource
         {
             get => _imageSource;

--- a/Models/DeckLibrary.cs
+++ b/Models/DeckLibrary.cs
@@ -2,6 +2,7 @@
 using PokeMemo.Utility;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace PokeMemo.Models
@@ -10,7 +11,7 @@ namespace PokeMemo.Models
     public partial class DeckLibrary : ObservableObject
     {
         // The Decks property is a list of Deck objects that represent the different decks available in the application.
-        public List<Deck> Decks { get; set; }
+        public ObservableCollection<Deck> Decks { get; set; }
 
         // The SelectedDeck property is used to store the currently selected deck in the application.
         // It is used by the PreviewDeck View, Quiz View, ModifyDeck View and CreateCard View to display / modify / add cards to the selected deck.
@@ -50,13 +51,13 @@ namespace PokeMemo.Models
             };
 
             // The list of Decks is initialized with some dummy data for testing and demonstration purposes.
-            Decks = new List<Deck>
-                {
-                    CreateDeck("Multiplication Deck", "Maths", "Water"),
-                    CreateDeck("Addition Deck", "Maths", "Electric"),
-                    CreateDeck("Greetings Deck", "Spanish", "Fire"),
-                    CreateDeck("Animals Deck", "Science", "Grass"),
-                };
+            Decks = new ObservableCollection<Deck>()
+            {
+                CreateDeck("Multiplication Deck", "Maths", "Water"),
+                CreateDeck("Addition Deck", "Maths", "Electric"),
+                CreateDeck("Greetings Deck", "Spanish", "Fire"),
+                CreateDeck("Animals Deck", "Science", "Grass"),
+            };
 
             var multDeck = Decks.FirstOrDefault(d => d.Name == "Multiplication Deck");
             multDeck?.Cards.Add(new Card("What is 1 x 1?", "1", multDeck.BackgroundColour, multDeck.ForegroundColour, multDeck.BorderColour, ImageHelper.GetImageByType(multDeck.Type)));

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -149,6 +149,13 @@ namespace PokeMemo.ViewModels
                     _deckToBeModified.ImageSource = DeckLibrary.SelectedType.ImageSource;
                     
                     /* Update the cards within the deck with the new type and its corresponding colours */
+                    foreach (Card card in _deckToBeModified.Cards)
+                    {
+                        card.BackgroundColour = DeckLibrary.SelectedType.BackgroundColour;
+                        card.ForegroundColour = DeckLibrary.SelectedType.ForegroundColour;
+                        card.BorderColour = DeckLibrary.SelectedType.BorderColour;
+                        card.ImageSource = DeckLibrary.SelectedType.ImageSource;
+                    }
                     
                     NavigateToDeckLibraryView();
                     return;

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -154,7 +154,9 @@ namespace PokeMemo.ViewModels
                         card.BackgroundColour = DeckLibrary.SelectedType.BackgroundColour;
                         card.ForegroundColour = DeckLibrary.SelectedType.ForegroundColour;
                         card.BorderColour = DeckLibrary.SelectedType.BorderColour;
-                        card.ImageSource = DeckLibrary.SelectedType.ImageSource;
+
+                        string pokemonImage = ImageHelper.GetImageByType(DeckLibrary.SelectedType);
+                        card.ImageSource = ImageHelper.LoadFromResource(pokemonImage);
                     }
                     
                     NavigateToDeckLibraryView();

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -76,17 +76,6 @@ namespace PokeMemo.ViewModels
             }
         }
 
-        private string _leftButtonText;
-        public string LeftButtonText
-        {
-            get => _leftButtonText;
-            set
-            {
-                _leftButtonText = value;
-                OnPropertyChanged();
-            }
-        }
-
         /*
          * Setting up view navigation by creating RelayCommands that call on functions
          * that update the CurrentViewModel in MainWindowViewModel
@@ -108,8 +97,6 @@ namespace PokeMemo.ViewModels
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             NavigateToCreateCardViewCommand = new RelayCommand(NavigateToCreateCardView);
             SaveDeckAndExitCommand = new RelayCommand(SaveDeckAndExit);
-
-            LeftButtonText = "Save deck and exit";
         }
 
         /*
@@ -126,7 +113,6 @@ namespace PokeMemo.ViewModels
             _deckToBeModified = deckToBeModified;
             Name = deckToBeModified?.Name;
             Category = deckToBeModified?.Category;
-            LeftButtonText = "Modify deck and exit";
         }
 
         // Navigation functions
@@ -172,7 +158,7 @@ namespace PokeMemo.ViewModels
             /* Return if either the name or category field is empty */
             IsNameEmpty = string.IsNullOrEmpty(Name);
             IsCategoryEmpty = string.IsNullOrEmpty(Category);
-            IsDeckTypeNotSelected = DeckLibrary.SelectedType == null;
+            // IsDeckTypeNotSelected = DeckLibrary.SelectedType == null;
 
             if (IsNameEmpty || IsCategoryEmpty || IsDeckTypeNotSelected) return false;
 

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -175,7 +175,11 @@ namespace PokeMemo.ViewModels
         // selected a theme for the deck before returning true
         private bool CheckIfFieldsAreValid()
         {
-            /* Return if either the name or category field is empty */
+            /*
+             * Return if either the name or category fields are empty, or if a new type
+             * hasn't been selected. Depending on which one isn't satisfied, insert a warning
+             * into the UI to alert the user and prevent them from saving.
+             */
             IsNameEmpty = string.IsNullOrEmpty(Name);
             IsCategoryEmpty = string.IsNullOrEmpty(Category);
             IsDeckTypeNotSelected = DeckLibrary.SelectedType == null;

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -178,7 +178,7 @@ namespace PokeMemo.ViewModels
             /* Return if either the name or category field is empty */
             IsNameEmpty = string.IsNullOrEmpty(Name);
             IsCategoryEmpty = string.IsNullOrEmpty(Category);
-            // IsDeckTypeNotSelected = DeckLibrary.SelectedType == null;
+            IsDeckTypeNotSelected = DeckLibrary.SelectedType == null;
 
             if (IsNameEmpty || IsCategoryEmpty || IsDeckTypeNotSelected) return false;
 

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.ApplicationLifetimes;
+﻿using System;
+using Avalonia.Controls.ApplicationLifetimes;
 using System.Windows.Input;
 using Avalonia;
 using CommunityToolkit.Mvvm.Input;
@@ -107,6 +108,7 @@ namespace PokeMemo.ViewModels
          */
         public CreateDeckViewModel(Deck? deckToBeModified)
         {
+            DeckLibrary = DataService.Instance.DeckLibrary;
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             SaveDeckAndExitCommand = new RelayCommand(SaveDeckAndExit);
 
@@ -137,8 +139,17 @@ namespace PokeMemo.ViewModels
             {
                 if (CheckIfFieldsAreValid())
                 {
+                    /* Set the new name, category and colours depending on the type selected */
                     _deckToBeModified.Name = Name;
                     _deckToBeModified.Category = Category;
+                    _deckToBeModified.Type = DeckLibrary.SelectedType;
+                    _deckToBeModified.BackgroundColour = DeckLibrary.SelectedType.BackgroundColour;
+                    _deckToBeModified.ForegroundColour = DeckLibrary.SelectedType.ForegroundColour;
+                    _deckToBeModified.BorderColour = DeckLibrary.SelectedType.BorderColour;
+                    _deckToBeModified.ImageSource = DeckLibrary.SelectedType.ImageSource;
+                    
+                    /* Update the cards within the deck with the new type and its corresponding colours */
+                    
                     NavigateToDeckLibraryView();
                     return;
                 }

--- a/ViewModels/CreateDeckViewModel.cs
+++ b/ViewModels/CreateDeckViewModel.cs
@@ -95,6 +95,7 @@ namespace PokeMemo.ViewModels
         public ICommand NavigateToCreateCardViewCommand { get; }
 
         public ICommand SaveDeckAndExitCommand { get; }
+        
         /*
          * Initialise the view with empty fields to create a new deck and
          * set the content of the button to indicate to the user that they
@@ -112,15 +113,13 @@ namespace PokeMemo.ViewModels
         }
 
         /*
-         * If there is a card to be modified, set this and the corresponding fields
+         * If there is a deck to be modified, set this and the corresponding fields
          * in the view to its existing Question and Answer fields. This will also
          * set the button to indicate to the user that they're modifying an existing
-         * card and then exiting.
+         * deck and then exiting.
          */
         public CreateDeckViewModel(Deck? deckToBeModified)
         {
-            DeckLibrary = DataService.Instance.DeckLibrary;
-            CurrentDeck = DataService.Instance.DeckLibrary.SelectedDeck;
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             SaveDeckAndExitCommand = new RelayCommand(SaveDeckAndExit);
 

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -30,7 +30,7 @@ namespace PokeMemo.ViewModels
         public MainWindowViewModel()
         {
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibrary);
-            NavigateToCreateDeckViewCommand = new RelayCommand(NavigateToCreateDeckView);
+            NavigateToCreateDeckViewCommand = new RelayCommand<Deck>(NavigateToCreateDeckView);
             NavigateToPreviewDeckViewCommand = new RelayCommand(NavigateToPreviewDeckView);
             NavigateToCreateCardViewCommand = new RelayCommand<Card>(NavigateToCreateCardView);
             NavigateToQuizViewCommand = new RelayCommand(NavigateToQuizView);
@@ -43,9 +43,16 @@ namespace PokeMemo.ViewModels
         {
             CurrentView = new DeckLibraryViewModel();
         }
-        private void NavigateToCreateDeckView()
+        private void NavigateToCreateDeckView(Deck? selectedDeck)
         {
-            CurrentView = new CreateDeckViewModel();
+            if (selectedDeck == null)
+            {
+                CurrentView = new CreateDeckViewModel();
+            }
+            else
+            {
+                CurrentView = new CreateDeckViewModel(selectedDeck);
+            }
         }
         private void NavigateToPreviewDeckView()
         {

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -94,7 +94,10 @@ namespace PokeMemo.ViewModels
         // Delete the selected deck
         private void DeleteDeck()
         {
-            
+            if (DeckLibrary.SelectedDeck != null)
+            {
+                DeckLibrary.Decks.Remove(DeckLibrary.SelectedDeck);
+            }
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -23,6 +23,8 @@ namespace PokeMemo.ViewModels
         public ICommand NavigateToCreateCardViewCommand { get; }
         public ICommand ModifyCardCommand { get; }
         public ICommand DeleteSelectedCardsCommand { get; }
+        public ICommand ModifyDeckCommand { get; }
+        public ICommand DeleteDeckCommand { get; }
 
         // The SelectedCard property / list of SelectedCards is used to store the card(s) that the user has selected
         // This is passed to the CreateCardViewModel when the user wants to modify a card
@@ -38,6 +40,8 @@ namespace PokeMemo.ViewModels
             NavigateToCreateCardViewCommand = new RelayCommand<Card>(NavigateToCreateCardView);
             ModifyCardCommand = new RelayCommand(ModifyCard);
             DeleteSelectedCardsCommand = new RelayCommand(DeleteSelectedCards);
+            ModifyDeckCommand = new RelayCommand(ModifyDeck);
+            DeleteDeckCommand = new RelayCommand(DeleteDeck);
         }
 
         // The following methods are used to navigate to other views - they link to the commands above
@@ -79,6 +83,18 @@ namespace PokeMemo.ViewModels
             {
                 DeckLibrary?.SelectedDeck?.Cards.RemoveMany(SelectedCards);
             }
+        }
+        
+        // Modify the selected deck
+        private void ModifyDeck()
+        {
+            
+        }
+        
+        // Delete the selected deck
+        private void DeleteDeck()
+        {
+            
         }
     }
 }

--- a/ViewModels/PreviewDeckViewModel.cs
+++ b/ViewModels/PreviewDeckViewModel.cs
@@ -21,6 +21,7 @@ namespace PokeMemo.ViewModels
         // Commands to navigate to other views
         public ICommand NavigateToDeckLibraryViewCommand { get; }
         public ICommand NavigateToCreateCardViewCommand { get; }
+        public ICommand NavigateToCreateDeckViewCommand { get; }
         public ICommand ModifyCardCommand { get; }
         public ICommand DeleteSelectedCardsCommand { get; }
         public ICommand ModifyDeckCommand { get; }
@@ -38,9 +39,11 @@ namespace PokeMemo.ViewModels
             
             NavigateToDeckLibraryViewCommand = new RelayCommand(NavigateToDeckLibraryView);
             NavigateToCreateCardViewCommand = new RelayCommand<Card>(NavigateToCreateCardView);
+            NavigateToCreateDeckViewCommand = new RelayCommand<Deck>(NavigateToCreateDeckView);
             ModifyCardCommand = new RelayCommand(ModifyCard);
             DeleteSelectedCardsCommand = new RelayCommand(DeleteSelectedCards);
             ModifyDeckCommand = new RelayCommand(ModifyDeck);
+            
             DeleteDeckCommand = new RelayCommand(DeleteDeck);
         }
 
@@ -69,6 +72,25 @@ namespace PokeMemo.ViewModels
                 mainWindowViewModel?.NavigateToCreateCardViewCommand.Execute(selectedCard);
             }
         }
+        
+        /*
+         * Navigate to the same view to create a deck, except overload the constructor of its
+         * view model by passing in the selected deck. This will prompt the view model to set
+         * up the view for modification of the deck instead.
+         */
+        private void NavigateToCreateDeckView(Deck? selectedDeck)
+        {
+            var mainWindowViewModel = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow?.DataContext as MainWindowViewModel;
+
+            if (selectedDeck == null)
+            {
+                mainWindowViewModel?.NavigateToCreateDeckViewCommand.Execute(null);
+            }
+            else
+            {
+                mainWindowViewModel?.NavigateToCreateDeckViewCommand.Execute(selectedDeck);
+            }
+        }
 
         // Works with the above method to modify the selected card
         private void ModifyCard()
@@ -88,7 +110,7 @@ namespace PokeMemo.ViewModels
         // Modify the selected deck
         private void ModifyDeck()
         {
-            
+           NavigateToCreateDeckViewCommand.Execute(DeckLibrary.SelectedDeck); 
         }
         
         // Delete the selected deck

--- a/Views/CreateDeckView.axaml
+++ b/Views/CreateDeckView.axaml
@@ -93,7 +93,7 @@
 		<!-- Button to create new deck -->
 		<DockPanel>
 			<StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-				<Button Content="Create Deck" Command="{Binding SaveDeckAndExitCommand}" IsEnabled="True" Padding="20" />
+				<Button Content="Save" Command="{Binding SaveDeckAndExitCommand}" IsEnabled="True" Padding="20" />
 			</StackPanel>
 		</DockPanel>
 	</StackPanel>

--- a/Views/PreviewDeckView.axaml
+++ b/Views/PreviewDeckView.axaml
@@ -47,7 +47,6 @@
 				<Button
 					Content="Modify Deck"
 					Command="{Binding ModifyDeckCommand}"
-					CommandParameter="{Binding SelectedCard}"
 					HorizontalAlignment="Right"
 					Padding="10"
 					Margin="10,0"


### PR DESCRIPTION
Modify and delete deck was *not* working and needed significant changes to get it working even though it was based upon the techniques used to delete and modify a card.

## Deleting a deck

This was done by taking the data binding to the currently selected deck, making sure it's not `null` and then removing it from the `ObservableCollection<Deck> Decks` variable.

## Modifying a deck

This involved a lot of changes, including constructor overloading and overriding the existing getters and setters to call `OnPropertyChanged()` whenever something was updated. Furthermore, each deck and each card within the deck being modified had to have their colours updated based on the type that was selected.